### PR TITLE
upgrade dp-kafka to v2.4.3 for healtcheck WARNING fix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ func Get() (*Config, error) {
 		ZebedeeURL:              "http://localhost:8082",
 		ReportEventTopic:        "report-events",
 		ReportEventGroup:        "dp-import-reporter",
-		KafkaBrokers:            []string{"localhost:9092"},
+		KafkaBrokers:            []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 		KafkaVersion:            "1.0.2",
 		KafkaOffsetOldest:       true,
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,7 +14,7 @@ var (
 	expectedConfig = &Config{
 		ReportEventGroup:        "dp-import-reporter",
 		ReportEventTopic:        "report-events",
-		KafkaBrokers:            []string{"localhost:9092"},
+		KafkaBrokers:            []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 		KafkaVersion:            "1.0.2",
 		KafkaSecProtocol:        "",
 		KafkaOffsetOldest:       true,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.43.0 // indirect
 	github.com/ONSdigital/dp-healthcheck v1.1.3 // indirect
-	github.com/ONSdigital/dp-kafka/v2 v2.4.2
+	github.com/ONSdigital/dp-kafka/v2 v2.4.3
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/go-ns v0.0.0-20210916104633-ac1c1c52327e
 	github.com/ONSdigital/log.go/v2 v2.0.9

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=
 github.com/ONSdigital/dp-healthcheck v1.1.3 h1:i9WV6BNdZFoefHCxmPle2OunNHUd8WnUqkDdK0OXhZU=
 github.com/ONSdigital/dp-healthcheck v1.1.3/go.mod h1:Wu3Um1Dd99K9rH41KfeCvuw8dxgVGsghj0tzT+yp8So=
-github.com/ONSdigital/dp-kafka/v2 v2.4.2 h1:Wur0nzhqcyEsS+W02OukjxvdzJ3hYeIqy/ySdXk+44w=
-github.com/ONSdigital/dp-kafka/v2 v2.4.2/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3 h1:Sb5nc4M3RsDMDmclsTqyjTMP6IBD7dRkv3kaIM26LLs=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=


### PR DESCRIPTION
### What

- Upgrade `dp-kafka` dependency to v2.4.3 to use the healthcheck fix where kafka producers/consumers will have a `warning` health (instead of `critical`) if enough brokers are available
  - min 2 brokers for producers
  - min 1 broker for consumers
- kafkaAddr match brokers in dp-compose

### How to review

Make sure `dp-kafka` dependency is upgraded

### Who can review

anyone